### PR TITLE
PHPがCGIで動いている場合、INPUT_SERVERが取れないかもしれない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+token.php

--- a/instagram.php
+++ b/instagram.php
@@ -1,5 +1,8 @@
 <?php
-    $access_token = '211242.....';
+  $include_path = './';
+  $token_file = 'token.php';
+  require($include_path . $token_file);
+  $access_token = ACCESS_TOKEN;
     $request_url  = 'https://api.instagram.com/v1/users/self/media/recent/';
   if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') == 'GET'){
     echo @file_get_contents($request_url.'?access_token='.$access_token);

--- a/instagram.php
+++ b/instagram.php
@@ -1,7 +1,10 @@
 <?php
-  if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') == 'GET'){
     $access_token = '211242.....';
     $request_url  = 'https://api.instagram.com/v1/users/self/media/recent/';
+  if (filter_input(INPUT_SERVER, 'REQUEST_METHOD') == 'GET'){
+    echo @file_get_contents($request_url.'?access_token='.$access_token);
+    exit;
+  } elseif (filter_input(INPUT_ENV, 'REQUEST_METHOD') == 'GET'){
     echo @file_get_contents($request_url.'?access_token='.$access_token);
     exit;
   }

--- a/token.php.sample
+++ b/token.php.sample
@@ -1,0 +1,6 @@
+<?php
+  define(
+    'ACCESS_TOKEN', '211242.....'
+  );
+?>
+


### PR DESCRIPTION
便利なプラグインだったので使わせていただいています。
度々、重箱の隅をつつくようでもうしわけないのですが、おもに私の利便性のためだけの変更で重要なので取り込んでもらわなくてもいいですが

レンタルサーバーなどPHPがCGIで動いている場合にINPUT_SERVERでNULLが返ってきてしまうので、INPUT_ENVを追加しました。
（filter_inputの意図と違っていたらすいません）

それにともなって、$access_tokenと$request_urlを外に出しています。

ついでにAccess Tokenを別ファイルにして、いろいろな場面で利用できるようにさせていただきました。Access Tokenが書かれたファイルは.gitignoreで無視するようにしています。
これも私の使い勝手だけの問題なので重要ではないです。
